### PR TITLE
Feature jwt login 1.1.0

### DIFF
--- a/backend/src/main/java/com/hot6/pnureminder/JWT/JwtTokenProvider.java
+++ b/backend/src/main/java/com/hot6/pnureminder/JWT/JwtTokenProvider.java
@@ -31,11 +31,10 @@ public class JwtTokenProvider {
     }
 
     // 유저 정보를 가지고 AccessToken, RefreshToken 을 생성하는 메서드
-    public TokenDto generateToken(Authentication authentication) {
-        // 권한 가져오기
-        String authorities = authentication.getAuthorities().stream()
-                .map(GrantedAuthority::getAuthority)
-                .collect(Collectors.joining(","));
+    public TokenDto generateToken(String memberId, String keyword) {
+
+        Claims claims = Jwts.claims().setSubject(memberId);
+        claims.put("keywords", keyword);
 
         long now = (new Date()).getTime();
         Integer min = 60000;
@@ -43,8 +42,7 @@ public class JwtTokenProvider {
         Date accessTokenExpiresIn = new Date(now + 30*min);
 
         String accessToken = Jwts.builder()
-                .setSubject(authentication.getName())
-                .claim("auth", authorities)
+                .setClaims(claims)
                 .setExpiration(accessTokenExpiresIn)
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();

--- a/backend/src/main/java/com/hot6/pnureminder/controller/MemberController.java
+++ b/backend/src/main/java/com/hot6/pnureminder/controller/MemberController.java
@@ -1,10 +1,12 @@
 package com.hot6.pnureminder.controller;
 
+import com.hot6.pnureminder.Dto.LoginDto;
 import com.hot6.pnureminder.Dto.SignUpDto;
 import com.hot6.pnureminder.Dto.TokenDto;
 import com.hot6.pnureminder.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -27,9 +29,8 @@ public class MemberController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<TokenDto> loginSuccess (@RequestBody Map<String,String> loginForm){
-        TokenDto token = memberService.login(loginForm.get("memberId"), loginForm.get("password"));
-        return ResponseEntity.ok(token);
+    public ResponseEntity login (@RequestBody LoginDto loginDto){
+        return new ResponseEntity(memberService.login(loginDto), HttpStatus.OK);
     }
 
 

--- a/backend/src/main/java/com/hot6/pnureminder/service/MemberService.java
+++ b/backend/src/main/java/com/hot6/pnureminder/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.hot6.pnureminder.service;
 
+import com.hot6.pnureminder.Dto.LoginDto;
 import com.hot6.pnureminder.Dto.SignUpDto;
 import com.hot6.pnureminder.Dto.TokenDto;
 import com.hot6.pnureminder.JWT.JwtTokenProvider;
@@ -27,19 +28,20 @@ public class MemberService {
     private final JwtTokenProvider jwtTokenProvider;
 
     @Transactional
-    public TokenDto login(String memberId, String password){
-        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(memberId, password);
-        Authentication authentication=authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+    public TokenDto login(LoginDto loginDto){
+        Member member = memberRepository.findByMemberId(loginDto.getMemberId())
+                .orElseThrow(() -> new IllegalArgumentException("아이디가 존재하지 않습니다."));
 
-        TokenDto tokenDto = jwtTokenProvider.generateToken(authentication);
+        if(encoder.matches(loginDto.getPassword(), member.getPassword())) {
+            throw  new IllegalArgumentException("패스워드가 일치하지 않습니다.");
+        }
 
-        return tokenDto;
+        return jwtTokenProvider.generateToken(member.getMemberId(), member.getKeyword());
     }
 
     @Transactional
     public String signUp(SignUpDto signUpDto) throws Exception{
         boolean existcheck = checkMemberId(signUpDto.getMemberId());
-
         if (existcheck) {
             throw new IllegalArgumentException("이미 존재하는 아이디입니다.");
         }


### PR DESCRIPTION
# 변경점 👍
토큰 발급 형식을 security.authentication.UsernamePasswordAuthenticationToken에서 
 지원해주는 인증객체 방식에서 Map<String,String>으로 받아와서 발급되게 리팩터링하였다. 

이유는 토큰 탑재시에 오류가 나서였지만 본 프로젝트 특성상 유저간 권한 차이도 존재하지 않고 별도의 관리자 계정도 존재할 필요가 없기에 id,pw를 받아와서 토큰 발급을 진행하였다. 그에 따라 직접 Exception 을 핸들링하는 코드도 추가하였다.

로그인시에 id가 가입되지 않은 아이디일때, pw가 일치하지 않을때 각각에 대해서는 코드를 제작해놓았지만 아직 프론트로 보내는 기능는 작성하지 않았다.

초반에는 회원코드로 구현할 정도로 개인정보에 대한 민감도가 낮고 정보보호에 대한 중요도(데이터 변화가 잦을 키워드 저장 기능)도 낮기 때문에 추후 계정 변경이나 계정 찾기 기능들은 프로젝트기능이 완성된 후에 제작할 예정이다.


현재로서는 
![image](https://user-images.githubusercontent.com/81455273/227703477-2ad46dc8-6690-46a8-9e7d-8f2725e0f4a5.png)
로그인 시에 accessToken과 refreshToken 그리고 grantType을 json의 body내에 보내주는 기능까지 완료되었다.

해당 기능은 아래 Postman 명세에서 자세히 확인 가능하다.
https://orange-capsule-383734.postman.co/workspace/New-Team-Workspace~fbfa367f-533b-4f45-bbe9-5af93089e4c8/collection/23411379-752b439f-184d-4ade-93f9-ded3d1bc624c?action=share&creator=23411379


