### PR TITLE
RELEASE Func1 [기능 1] ver. 1.0.0   (jwt signup/login/tokenReissue)

### DIFF
--- a/backend/src/main/java/com/hot6/pnureminder/controller/AuthController.java
+++ b/backend/src/main/java/com/hot6/pnureminder/controller/AuthController.java
@@ -1,9 +1,6 @@
 package com.hot6.pnureminder.controller;
 
-import com.hot6.pnureminder.dto.MemberRequestDto;
-import com.hot6.pnureminder.dto.MemberResponseDto;
-import com.hot6.pnureminder.dto.TokenDto;
-import com.hot6.pnureminder.dto.TokenRequestDto;
+import com.hot6.pnureminder.dto.*;
 import com.hot6.pnureminder.service.AuthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -24,8 +21,8 @@ public class AuthController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<TokenDto> login(@RequestBody MemberRequestDto memberRequestDto) {
-        return ResponseEntity.ok(authService.login(memberRequestDto));
+    public ResponseEntity<TokenDto> login(@RequestBody LoginDto loginDto) {
+        return ResponseEntity.ok(authService.login(loginDto));
     }
 
     @PostMapping("/reissue")

--- a/backend/src/main/java/com/hot6/pnureminder/dto/LoginDto.java
+++ b/backend/src/main/java/com/hot6/pnureminder/dto/LoginDto.java
@@ -3,6 +3,7 @@ package com.hot6.pnureminder.dto;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.*;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 
 @Getter
 @Setter
@@ -13,9 +14,14 @@ public class LoginDto {
 
     @NotNull
     @Size(min = 3,max = 50)
-    private String name;
+    private String email;
 
     @NotNull
     @Size(min = 3,max = 100)
     private String password;
+
+    public UsernamePasswordAuthenticationToken toAuthentication() {
+        return new UsernamePasswordAuthenticationToken(email, password);
+
+    }
 }

--- a/backend/src/main/java/com/hot6/pnureminder/dto/MemberRequestDto.java
+++ b/backend/src/main/java/com/hot6/pnureminder/dto/MemberRequestDto.java
@@ -2,10 +2,10 @@ package com.hot6.pnureminder.dto;
 
 import com.hot6.pnureminder.entity.Authority;
 import com.hot6.pnureminder.entity.Member;
+import jakarta.persistence.Column;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Getter
@@ -16,15 +16,20 @@ public class MemberRequestDto {
     private String email;
     private String password;
 
+    private String nickname;
+
+    private Integer findQuesNum;
+    private String findAnswer;
     public Member toMember(PasswordEncoder passwordEncoder) {
         return Member.builder()
             .email(email)
             .password(passwordEncoder.encode(password))
+                .nickname(nickname)
+                .findQuesNum(findQuesNum)
+                .findAnswer(findAnswer)
             .authority(Authority.ROLE_USER)
             .build();
     }
 
-    public UsernamePasswordAuthenticationToken toAuthentication() {
-        return new UsernamePasswordAuthenticationToken(email, password);
-    }
+
 }

--- a/backend/src/main/java/com/hot6/pnureminder/service/AuthService.java
+++ b/backend/src/main/java/com/hot6/pnureminder/service/AuthService.java
@@ -1,9 +1,6 @@
 package com.hot6.pnureminder.service;
 
-import com.hot6.pnureminder.dto.MemberRequestDto;
-import com.hot6.pnureminder.dto.MemberResponseDto;
-import com.hot6.pnureminder.dto.TokenDto;
-import com.hot6.pnureminder.dto.TokenRequestDto;
+import com.hot6.pnureminder.dto.*;
 import com.hot6.pnureminder.entity.Member;
 import com.hot6.pnureminder.entity.RefreshToken;
 import com.hot6.pnureminder.jwt.TokenProvider;
@@ -37,9 +34,9 @@ public class AuthService {
     }
 
     @Transactional
-    public TokenDto login(MemberRequestDto memberRequestDto) {
+    public TokenDto login(LoginDto loginDto) {
         // 1. Login ID/PW 를 기반으로 AuthenticationToken 생성
-        UsernamePasswordAuthenticationToken authenticationToken = memberRequestDto.toAuthentication();
+        UsernamePasswordAuthenticationToken authenticationToken = loginDto.toAuthentication();
 
         // 2. 실제로 검증 (사용자 비밀번호 체크) 이 이루어지는 부분
         //    authenticate 메서드가 실행이 될 때 CustomUserDetailsService 에서 만들었던 loadUserByUsername 메서드가 실행됨


### PR DESCRIPTION
Amazon EC2 서버 내에 nohup 배포 완료 0331 02:14분 기준

Amazon EC2 - Amzon RDS 서비스간 DB 연결 완료



## http://3.34.82.40:8080/auth/signup  회원가입 기능


findQuesNum 의 경우에는 비밀번호 찾을때 사용하는 질문지를 가르키는 int형 으로

예로 들어


어릴적 보물 1호는?  - > 1


내가 다닌 초등학교는? -> 2

```
{
 "email":"test1@email.com",
 "password" : "testPassword1234",
 "nickname" : "닉네임",
 "findQuesNum" : <int 형으로>,
 "findAnswer" : "질문에 대한 답"
}
```


## http://3.34.82.40:8080/auth/login  로그인 기능


```
{
 "email":"test1@email.com",
 "password" : "testPassword1234"
}
```


## http://3.34.82.40:8080/auth/reissue 토큰 재발급 기능


```
{
 "accessToken": ~~,
 "refreshToken" : ~~
}
```


## http://3.34.82.40:8080/api/main 메인페이지


## http://localhost:8080/api/member/{가입시 이메일} 기능 2 구현을 위한 테스트페이지





