### PR TITLE
Feature nearRoom 2.0.0

### DIFF
--- a/backend/src/main/java/com/hot6/pnureminder/dto/LectureRoomDto.java
+++ b/backend/src/main/java/com/hot6/pnureminder/dto/LectureRoomDto.java
@@ -1,27 +1,50 @@
 package com.hot6.pnureminder.dto;
 
-import com.fasterxml.jackson.annotation.JsonManagedReference;
-import com.hot6.pnureminder.entity.Building;
 import com.hot6.pnureminder.entity.Lecture;
 import com.hot6.pnureminder.entity.LectureRoom;
-import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor
 public class LectureRoomDto {
     private Integer id;
+    private String roomNum;
     private List<Lecture> lectures;
+    private Lecture earliestStartLecture;
+
 
     public static LectureRoomDto toDto(LectureRoom lectureRoom){
 
         return new LectureRoomDto(
                 lectureRoom.getId(),
-                lectureRoom.getLectures()
+                lectureRoom.getRoomNum(),
+                lectureRoom.getLectures(),
+                null
         );
     }
+
+    public static LectureRoomDto toDto(LectureRoom lectureRoom, Optional<Lecture> earliestStartLecture) {
+        return new LectureRoomDto(
+                lectureRoom.getId(),
+                lectureRoom.getRoomNum(),
+                null,
+                earliestStartLecture.orElse(null)
+        );
+    }
+
+    // 기본 생성자는 private으로 설정하여 외부에서 호출되지 않도록 한다.
+    private LectureRoomDto(Integer id, String roomNum, List<Lecture> lectures, Lecture earliestStartLecture) {
+        this.id = id;
+        this.roomNum = roomNum;
+        this.lectures = lectures;
+        this.earliestStartLecture = earliestStartLecture;
+    }
+
+
 }

--- a/backend/src/main/java/com/hot6/pnureminder/repository/LectureRepository.java
+++ b/backend/src/main/java/com/hot6/pnureminder/repository/LectureRepository.java
@@ -4,10 +4,14 @@ import com.hot6.pnureminder.entity.Lecture;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface LectureRepository extends JpaRepository<Lecture, Integer> {
 
     List<Lecture> findAllByLectureRoomId (Integer lectureRoomId);
 
     List<Lecture> findAllByLectureRoomIdAndDayOfWeek(Integer lectureRoomId, Integer dayOfWeek);
+
+    Optional<Lecture> findLectureById(Integer id);
+
 }

--- a/backend/src/main/java/com/hot6/pnureminder/repository/LectureRepository.java
+++ b/backend/src/main/java/com/hot6/pnureminder/repository/LectureRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 public interface LectureRepository extends JpaRepository<Lecture, Integer> {
 
     List<Lecture> findAllByLectureRoomId (Integer lectureRoomId);
+
+    List<Lecture> findAllByLectureRoomIdAndDayOfWeek(Integer lectureRoomId, Integer dayOfWeek);
 }

--- a/backend/src/main/java/com/hot6/pnureminder/service/BuildingService.java
+++ b/backend/src/main/java/com/hot6/pnureminder/service/BuildingService.java
@@ -54,30 +54,37 @@ public class BuildingService {
 
 //       현재시간 추출
 //       현재 시간에서 세팅한 시간을 더해서 마진을 만든다
-        ZonedDateTime endTime = currentTime.plus(setMinutes, ChronoUnit.MINUTES);
+        ZonedDateTime marginTime = currentTime.plus(setMinutes, ChronoUnit.MINUTES);
 
-//       현재요일 추출
-        int currentDayOfWeek = (DayOfWeek.from(LocalDate.now()).getValue())-1;
+//       현재요일 추출 테스트
+        //int currentDayOfWeek = (DayOfWeek.from(LocalDate.now()).getValue())-1;
+        int currentDayOfWeek = 0;
 
 //       강의실 리스트 가져와서(LectureRoom pk로) 비어있는 강의실 확인 후 리스트화
         List<LectureRoomDto> availableLectureRooms = new ArrayList<>();
 
         for (LectureRoomDto lectureRoomDto : lectureRooms) {
-            List<LectureDto> lecturesInRoom = lectureService.findAllByLectureRoomId(lectureRoomDto.getId());
+            //List<LectureDto> lecturesInRoom = lectureService.findAllByLectureRoomId(lectureRoomDto.getId());
+            List<LectureDto> lecturesInRoom = lectureService.findAllByLectureRoomIdAndDayOfWeek(lectureRoomDto.getId(),currentDayOfWeek);
 
-            boolean isAvailableRoom = true;
+            boolean isAvailableRoom = false;
 
             for (LectureDto lectureDto : lecturesInRoom) {
                 ZonedDateTime lectureStartTime = lectureDto.getStartTime().toLocalTime().atDate(LocalDate.now()).atZone(ZoneId.of("Asia/Seoul"));
                 ZonedDateTime lectureEndTime = lectureStartTime.plus(lectureDto.getRunTime().toLocalTime().getHour(), ChronoUnit.HOURS).plus(lectureDto.getRunTime().toLocalTime().getMinute(), ChronoUnit.MINUTES);
+
+
 //                요일이 같고 현재 시간이 강의 시간+세팅시간과 겹칠때 isAvailable false
-                if (lectureDto.getDayOfWeek() == currentDayOfWeek && (endTime.isAfter(lectureStartTime) && currentTime.isBefore(lectureEndTime))) {
-                    isAvailableRoom = false;
+                boolean isEmptyNow = (marginTime.isBefore(lectureStartTime) || currentTime.isAfter(lectureEndTime));
+                boolean isToday = lectureDto.getDayOfWeek() == currentDayOfWeek;
+                if ( isToday && isEmptyNow) {
+                    isAvailableRoom = true;
                     break;
                 }
             }
 
             if (isAvailableRoom) {
+                lectureRoomDto.getId()
                 availableLectureRooms.add(lectureRoomDto);
             }
         }

--- a/backend/src/main/java/com/hot6/pnureminder/service/LectureRoomService.java
+++ b/backend/src/main/java/com/hot6/pnureminder/service/LectureRoomService.java
@@ -18,12 +18,10 @@ public class LectureRoomService {
 
     private final LectureRoomRepository lectureRoomRepository;
 
-    public List<LectureRoomDto> findAllByBuildingNum(Integer buildingNum) {
+    public List<LectureRoom> findAllByBuildingNum(Integer buildingNum) {
         List<LectureRoom> lectureRooms = lectureRoomRepository.findAllByBuildingNum(buildingNum);
 
-        return lectureRooms.stream()
-                .map(LectureRoomDto::toDto)
-                .collect(Collectors.toList());
+        return lectureRooms;
     }
 
 }

--- a/backend/src/main/java/com/hot6/pnureminder/service/LectureService.java
+++ b/backend/src/main/java/com/hot6/pnureminder/service/LectureService.java
@@ -24,6 +24,13 @@ public class LectureService {
                 .map(LectureDto::toDto)
                 .collect(Collectors.toList());
     }
+    public List<LectureDto> findAllByLectureRoomIdAndDayOfWeek(Integer lectureRoomId, Integer dayOfWeek) {
+        List<Lecture> lectureRooms = lectureRepository.findAllByLectureRoomIdAndDayOfWeek(lectureRoomId, dayOfWeek);
+
+        return lectureRooms.stream()
+                .map(LectureDto::toDto)
+                .collect(Collectors.toList());
+    }
 
 }
 

--- a/backend/src/main/java/com/hot6/pnureminder/service/LectureService.java
+++ b/backend/src/main/java/com/hot6/pnureminder/service/LectureService.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -24,12 +25,16 @@ public class LectureService {
                 .map(LectureDto::toDto)
                 .collect(Collectors.toList());
     }
-    public List<LectureDto> findAllByLectureRoomIdAndDayOfWeek(Integer lectureRoomId, Integer dayOfWeek) {
+    public List<Lecture> findAllByLectureRoomIdAndDayOfWeek(Integer lectureRoomId, Integer dayOfWeek) {
         List<Lecture> lectureRooms = lectureRepository.findAllByLectureRoomIdAndDayOfWeek(lectureRoomId, dayOfWeek);
 
-        return lectureRooms.stream()
-                .map(LectureDto::toDto)
-                .collect(Collectors.toList());
+        return lectureRooms;
+    }
+
+    public Optional<Lecture> findLectureById (Integer id){
+        Optional<Lecture> lecture = lectureRepository.findLectureById(id);
+
+        return lecture;
     }
 
 }

--- a/backend/src/main/java/com/hot6/pnureminder/util/DateTimeUtils.java
+++ b/backend/src/main/java/com/hot6/pnureminder/util/DateTimeUtils.java
@@ -8,7 +8,9 @@ public class DateTimeUtils {
 
     public static ZonedDateTime getCurrentSeoulTime() {
         ZoneId seoulZoneId = ZoneId.of("Asia/Seoul");
-        LocalDateTime localDateTime = LocalDateTime.now();
+        //LocalDateTime localDateTime = LocalDateTime.now();
+        //API 테스트용
+        LocalDateTime localDateTime = LocalDateTime.of(2023, 4, 24, 13, 00);
         ZonedDateTime seoulZonedDateTime = localDateTime.atZone(seoulZoneId);
         return seoulZonedDateTime;
     }

--- a/backend/src/main/java/com/hot6/pnureminder/util/DateTimeUtilsForTest.java
+++ b/backend/src/main/java/com/hot6/pnureminder/util/DateTimeUtilsForTest.java
@@ -8,18 +8,20 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 
-public class DateTimeUtils {
+public class DateTimeUtilsForTest {
+
+    private static LocalDateTime localDateTestTime = LocalDateTime.of(2023, 4, 24, 13, 00);
+
 
     public static ZonedDateTime getCurrentSeoulTime() {
         ZoneId seoulZoneId = ZoneId.of("Asia/Seoul");
-        LocalDateTime localDateTime = LocalDateTime.now();
-        ZonedDateTime seoulZonedDateTime = localDateTime.atZone(seoulZoneId);
+        ZonedDateTime seoulZonedDateTime = localDateTestTime.atZone(seoulZoneId);
         return seoulZonedDateTime;
     }
 
     public static ZonedDateTime getLectureStartTime(Lecture lecture) {
         ZoneId seoulZoneId = ZoneId.of("Asia/Seoul");
-        return lecture.getStartTime().toLocalTime().atDate(LocalDate.now()).atZone(seoulZoneId);
+        return lecture.getStartTime().toLocalTime().atDate(localDateTestTime.toLocalDate()).atZone(seoulZoneId);
     }
 
     public static ZonedDateTime getLectureEndTime(Lecture lecture) {


### PR DESCRIPTION
# 리팩토링 🛠
 리팩토링 내역

### 기존 구현 방식
![image](https://user-images.githubusercontent.com/81455273/235029659-5d0180bc-fc47-4a60-b585-f4fb12c3a4e3.png)

강의실 객체를 가져와주는 방식으로 각 강의실별로 몇시까지 사용이 가능한지(다음수업이 언제인지)에 관한 정보가 존재하지 않았었다.


### In version 2.0.0

**테스트를 위한 23년도 01학기 월요일의 오후 1시로 가정**
![image](https://user-images.githubusercontent.com/81455273/235029808-b8bae532-91bd-404e-8e6c-348dae6b20a5.png)

각 강의실 별로 현재 시간 기준 다음수업의 Lecture 객체를 출력하도록 하였다.
