### PR TITLE
Feature announcement with chatGPT

### DIFF
--- a/PNUtimetable-server/Announcement/announcement.py
+++ b/PNUtimetable-server/Announcement/announcement.py
@@ -1,0 +1,29 @@
+from amazon_rds.rds_connection import create_rds_session_for_announcement
+
+from sqlalchemy import Column, Integer, String
+from sqlalchemy.orm import declarative_base
+
+def save_culedu_announce_to_rds(announcements):
+    Base = declarative_base()
+
+    class CuleduAnnounce(Base):
+        __tablename__ = 'culedu_announce'
+
+        id = Column(Integer, primary_key=True, autoincrement=True)
+        title = Column(String)
+        urls = Column(String)
+
+    session = create_rds_session_for_announcement()
+    # Create RDS session
+
+    for announce in announcements:
+        new_announce = CuleduAnnounce(
+            title=announce['title'],
+            urls=announce['urls']
+        )
+        session.add(new_announce)
+
+    session.commit()
+
+    # 세션 종료
+    session.close()

--- a/PNUtimetable-server/Announcement/check_new_announcement.py
+++ b/PNUtimetable-server/Announcement/check_new_announcement.py
@@ -1,0 +1,41 @@
+# 필요한 패키지들
+from sqlalchemy import create_engine, Column, Integer, String
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+
+# 데이터베이스 연결 및 세션 생성
+DATABASE_URL = "mysql+pymysql://username:password@host/db_name"
+engine = create_engine(DATABASE_URL)
+Session = sessionmaker(bind=engine)
+session = Session()
+
+# 데이터베이스에 저장된 가장 최근 게시글의 제목을 가져오는 함수
+def get_latest_title_from_db(session):
+    result = session.query(Announcement).order_by(Announcement.id.desc()).first()
+    if result:
+        return result.title
+    else:
+        return None
+
+# 웹 사이트에서 가장 최근 게시글의 제목을 가져오는 함수
+def get_latest_title_from_web(driver):
+    # 웹 사이트로부터 가장 최근 게시글의 제목을 크롤링하는 코드 작성
+    pass
+
+# 가장 오래된 게시글을 데이터베이스에서 삭제하는 함수
+def delete_oldest_announcement(session):
+    oldest_announcement = session.query(Announcement).order_by(Announcement.id).first()
+    if oldest_announcement:
+        session.delete(oldest_announcement)
+        session.commit()
+
+# 메인 코드
+latest_title_from_db = get_latest_title_from_db(session)
+latest_title_from_web = get_latest_title_from_web(driver)
+
+if latest_title_from_db != latest_title_from_web:
+    # 크롤링 진행 및 새로운 게시글을 데이터베이스에 추가하는 코드 작성
+    pass
+
+    # 가장 오래된 게시글을 데이터베이스에서 삭제
+    delete_oldest_announcement(session)

--- a/PNUtimetable-server/Announcement/crawlAnnouncement.py
+++ b/PNUtimetable-server/Announcement/crawlAnnouncement.py
@@ -1,0 +1,79 @@
+
+# Selenium
+from selenium import webdriver
+from webdriver_manager.chrome import ChromeDriverManager
+from selenium.webdriver.chrome.service import Service
+from selenium.webdriver.common.by import By
+
+from Announcement.announcement import save_culedu_announce_to_rds
+
+from gpt_summarize.main import summarize_text
+
+MAX_TOKENS = 3500 - 150  # 150 tokens for completion
+def truncate_content(content):
+    tokens = content.split()
+    truncated_tokens = tokens[:MAX_TOKENS]
+    return ' '.join(truncated_tokens)
+def crawlAnnouncement(driver):
+    # Get HTML
+    driver.get('https://culedu.pusan.ac.kr/culedu/15027/subview.do')
+    driver.implicitly_wait(3)
+    titles_elements = driver.find_elements(By.CLASS_NAME, "_artclTdTitle")
+
+    data = []
+
+    # Collect all URLs first
+    urls_list = []
+    for title_element in titles_elements:
+        title = title_element.text
+        urls = title_element.find_element(By.TAG_NAME, 'a').get_attribute('href')
+        urls_list.append({"title": title, "urls": urls})
+
+    # Visit each URL and perform summarization
+    for url_info in urls_list:
+        title = url_info['title']
+        urls = url_info['urls']
+
+        driver.get(urls)
+        driver.implicitly_wait(3)
+        content = driver.find_element(By.CLASS_NAME, "artclView").text
+
+
+
+        # Then, in the crawlAnnouncement function:
+        truncated_content = truncate_content(content)
+        for i in range(5):
+            summarize_text(title, truncated_content)
+
+        driver.execute_script("window.open('');")
+        driver.switch_to.window(driver.window_handles[-1])
+
+        data.append({"title": title, "urls": urls})
+
+        driver.close()
+        driver.switch_to.window(driver.window_handles[0])
+        driver.implicitly_wait(3)
+
+        break
+
+    driver.quit()
+
+    print(data)
+
+    return data
+
+
+
+if __name__ == "__main__":
+    # Initialize the webdriver
+    chrome_options = webdriver.ChromeOptions()
+    chrome_options.add_argument('--headless')
+    chrome_options.add_argument('--no-sandbox')
+    chrome_options.add_argument('--disable-dev-shm-usage')
+    driver = webdriver.Chrome(service=Service(ChromeDriverManager().install()), options=chrome_options)
+    # Crawl the data
+    # crawled_data = crawlAnnouncement(driver)
+    crawlAnnouncement(driver)
+
+    # Save the data to the database
+    # save_culedu_announce_to_rds(crawled_data)

--- a/PNUtimetable-server/gpt_summarize/main.py
+++ b/PNUtimetable-server/gpt_summarize/main.py
@@ -1,0 +1,27 @@
+import openai
+from secret_info.my_openai_info import my_openai_token
+
+
+def summarize_text(title, text):
+    openai_token = my_openai_token()
+    openai.api_key = openai_token.token
+    # 요약할 텍스트 입력
+    prompt = f"제목 : {title} 내용:{text}\n\n 이 게시글을 사용자가 검색으로 접근하거나 이 게시글이 필요한 사용자에게 이 글을 설명할 수 있는 키워드를 5개에서 8개 사이로 보여줘 출력 형식은 키워드 사이에 , 를 추가해서 설명없이 출력하게 해주세요."
+
+    # 요청을 위한 파라미터 설정
+    params = {
+        "engine": "text-davinci-002",
+        "prompt": prompt,
+        "max_tokens": 200,
+        "n": 5,
+        "stop": None,
+        "temperature": 0.5,
+    }
+
+    # GPT API 요청
+    response = openai.Completion.create(**params)
+
+    # 요약 결과 추출 및 반환
+    summary = response.choices[0].text.strip()
+    print(summary)
+    return summary


### PR DESCRIPTION
# 변경점 👍
 공지사항 페이지를 크롤링 하여 각 공지사항 url과 제목을 프론트단에 제공하기 위해 amazon RDS 기반의 mySQL에 저장한다.

각 공지사항 url을 순차 방문하여 openAI사의 chat-gpt 모델 text-davinci-002를 이용한다.
아래는 사용된 모델의 스펙

````
 params = {
        "engine": "text-davinci-002",
        "prompt": prompt,
        "max_tokens": 200,
        "n": 5,
        "stop": None,
        "temperature": 0.5,
    }
````



총 같은 페이지를 5번 반복하거나 사용하는 요금제의 토큰 제한 전까지 반복을 한 이후에 각 stage에서의 결과값중 빈도가 높은 단어를 저장하여 유저들에게 검색 기능과 유저들에게 맞는 키워드 추천기능을 제공하여준다.

![image](https://user-images.githubusercontent.com/81455273/236961094-46397822-3af5-4147-b488-368c1e4065ea.png)



## 현재 방법의 한계
api 이용시에 일정 토큰을 넘으면 과금이 되는 방식도 존재하고 작업속도도 부정확한 키워드가 등록되지 않으려 같은 작업을 반복하여 빈도가 높은 키워드를 출력하게 하였기에 개당 2~3분정도의 시간이 걸린다.



결과물은 꽤나 정확하기에 현재로서는 instant하게 구현하여서 (공지사항이 업데이트 되면 바로 gpt를 이용해 summary 를 하는 방식. 하지만 token limit 등으로 인해 여러 요청이 밀리게되면 불가능하다.(최대 2개까지는 가능))



추후에는 타이밍을 이용해 업데이트가 되는 게시글을 queue에 올려놓고 token limit가 적용되지 않는 속도로 openai 쪽에 용청을 보내여 순차적으로 summarize를 하게 할 예정이다.


